### PR TITLE
build: Limit pydantic below 1.9 change flake8 link

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     hooks:
       - id: black_nbconvert
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.7.9
     hooks:
       - id: flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 packages = find:
 install_requires =
     firebolt-sdk>=0.9.2
-    pydantic
+    pydantic<1.9.0
     pyyaml
     sqlparse>=0.4.2
     types-PyYAML>=6.0.4


### PR DESCRIPTION
1.9 introduces the following error on import
```
tests/integration/test_engine.py:8: in <module>
    from firebolt_cli.main import main
src/firebolt_cli/main.py:7: in <module>
    from firebolt_cli.ingest import ingest
src/firebolt_cli/ingest.py:8: in <module>
    from firebolt_ingest.table_model import Table
venv/lib/python3.9/site-packages/firebolt_ingest/table_model.py:10: in <module>
    class YamlModelMixin(metaclass=ModelMetaclass):
pydantic/main.py:294: in pydantic.main.ModelMetaclass.__new__
    ???
E   AttributeError: type object 'YamlModelMixin' has no attribute '__try_update_forward_refs__'
```

Also gitlab link for flake8 is no longer accessible.