### PR TITLE
feat(Data-2568): added drop_outdated_partitions function which drops partitions in the fact table that are outdated, meaning the corresponding file in the external table has a more recent timestamp (was updated).

### DIFF
--- a/src/firebolt_ingest/table_service.py
+++ b/src/firebolt_ingest/table_service.py
@@ -356,7 +356,7 @@ class TableService:
             )
         if not self.table.partitions:
             raise FireboltError(
-                f"Fact table {self.external_table_name} is not partitioned"
+                f"Fact table {self.internal_table_name} is not partitioned"
             )
 
         outdated_partitions_query = f"SELECT DISTINCT {','.join([p.as_sql_string() for p in self.table.partitions])} \
@@ -371,7 +371,7 @@ class TableService:
         if outdated_partitions:
             q = "ALTER TABLE {table_name} DROP PARTITION {partition_expression}"
             for outdated_partition in outdated_partitions:
-                logger.info(
+                logger.debug(
                     f"Going to drop the following partitions: {outdated_partition}"
                 )
                 drop_partition_query = q.format(

--- a/src/firebolt_ingest/table_service.py
+++ b/src/firebolt_ingest/table_service.py
@@ -306,6 +306,66 @@ class TableService:
                 "Uncertain sync mode in config \
                 use insert_full_overwrite/insert_incremental_append instead"
             )
+        
+    def insert_and_refresh_outdated_partitions(self, use_materialized_query=False, **kwargs) -> None:
+        """
+        Gets outdated partition comparing MAX(source_file_timestamp) in fact table with 
+        MAX(source_file_timestamp) in external table and drops them.
+        Inserts data into a table based on the synchronization mode specified
+        in the table's configuration.
+
+        This method checks the `sync_mode` attribute of the associated table
+        and performs an insert operation accordingly.
+        If the `sync_mode` is set to "overwrite", it performs
+        a full overwrite of the data in the table.
+        If it's set to "append", it appends the new data incrementally.
+        For any other `sync_mode` values, a ValueError is raised, indicating
+        an uncertain sync mode configuration.
+
+        Args:
+        use_materialized_query (bool):
+            If set to True, the function uses an materialized query
+                strategy for insertion.
+            If set to False (default), the function uses the standard query approach.
+        **kwargs: Additional keyword arguments which may be passed to other functions
+            used in this method.
+        """
+        self.drop_outdated_partitions()
+        self.insert(use_materialized_query, **kwargs)
+
+    def drop_outdated_partitions(self):
+        """
+        Drops outdated partitions from the internal table if they exist.
+        """
+        cursor = self.connection.cursor()
+        if not does_table_exist(cursor, self.internal_table_name):
+            raise FireboltError(f"Fact table {self.internal_table_name} doesn't exist")
+        if not does_table_exist(cursor, self.external_table_name):
+            raise FireboltError(
+                f"External table {self.external_table_name} doesn't exist"
+            )
+        if not self.internal_table_name.partition:
+            raise FireboltError(
+                f"Fact table {self.external_table_name} is not partitioned"
+            )
+        
+        outdated_partitions_query = f"SELECT DISTINCT {",".join([p.as_sql_string() for p in self.internal_table_name.partition])} \
+        FROM {self.external_table_name} \
+        WHERE source_file_timestamp > ( SELECT MAX(source_file_timestamp) FROM {self.internal_table_name} )"
+
+        cursor.execute(query=format_query(outdated_partitions_query))
+        outdated_partitions = cursor.fetchall()
+        logger.info(f"List of outdated partitions: {outdated_partitions}")
+        
+        if outdated_partitions:
+            q = "ALTER TABLE {table_name} DROP PARTITION {partition_expression}"
+            for outdated_partition in outdated_partitions:
+                logger.info(f"Going to drop the following partitions: {outdated_partition}")
+                drop_partition_ddl = q.format(
+                    table_name=self.internal_table_name, partition_expression=",".join(map(str, outdated_partition))
+                )
+                cursor.execute(query=drop_partition_ddl)
+    
 
     def drop_internal_table(self) -> None:
         """

--- a/tests/unit/test_table_service.py
+++ b/tests/unit/test_table_service.py
@@ -354,7 +354,10 @@ def test_drop_tables(mocker: MockerFixture, mock_table: Table):
     cursor_mock.execute.assert_any_call(expected_query, [ts.external_table_name])
     cursor_mock.execute.assert_any_call(expected_query, [ts.internal_table_name])
 
-def test_drop_outdated_partitions_table_without_partitions(mocker: MockerFixture, mock_table: Table):
+
+def test_drop_outdated_partitions_table_without_partitions(
+    mocker: MockerFixture, mock_table: Table
+):
     """
     Test to check if the function 'drop_outdated_partitions' correctly
     drops the partitions in the fact table that are outdated.
@@ -370,6 +373,7 @@ def test_drop_outdated_partitions_table_without_partitions(mocker: MockerFixture
     with pytest.raises(FireboltError):
         ts.drop_outdated_partitions()
 
+
 def test_drop_outdated_partitions(mocker: MockerFixture, mock_table_partitioned: Table):
     """
     Test to check if the function 'drop_outdated_partitions' correctly
@@ -378,7 +382,6 @@ def test_drop_outdated_partitions(mocker: MockerFixture, mock_table_partitioned:
 
     connection = MagicMock()
     cursor_mock = MagicMock()
-    #cursor_mock.execute.return_value = 0
     connection.cursor.return_value = cursor_mock
 
     does_table_exists_mock = mocker.patch(
@@ -395,14 +398,19 @@ def test_drop_outdated_partitions(mocker: MockerFixture, mock_table_partitioned:
         query=format_query(
             """SELECT DISTINCT user,
                 EXTRACT(DAY FROM birthdate)
-            FROM ex_table_name 
-            WHERE source_file_timestamp > ( SELECT MAX(source_file_timestamp) FROM table_name)
+            FROM ex_table_name
+            WHERE source_file_timestamp > ( SELECT MAX(source_file_timestamp)
+                FROM table_name)
             """
         )
     )
 
-    cursor_mock.execute.assert_any_call(query="ALTER TABLE table_name DROP PARTITION user1,12")
-    cursor_mock.execute.assert_any_call(query="ALTER TABLE table_name DROP PARTITION user2,13")
+    cursor_mock.execute.assert_any_call(
+        query="ALTER TABLE table_name DROP PARTITION user1,12"
+    )
+    cursor_mock.execute.assert_any_call(
+        query="ALTER TABLE table_name DROP PARTITION user2,13"
+    )
 
     does_table_exists_mock.assert_any_call(cursor_mock, "table_name")
     does_table_exists_mock.assert_any_call(cursor_mock, "ex_table_name")

--- a/tests/unit/test_table_service.py
+++ b/tests/unit/test_table_service.py
@@ -370,7 +370,7 @@ def test_drop_outdated_partitions_table_without_partitions(
 
     ts = TableService(mock_table, connection)
 
-    does_table_exists_mock = mocker.patch(
+    mocker.patch(
         "firebolt_ingest.table_service.does_table_exist", return_value=[True, True]
     )
 
@@ -420,7 +420,9 @@ def test_drop_outdated_partitions(mocker: MockerFixture, mock_table_partitioned:
     does_table_exists_mock.assert_any_call(cursor_mock, "ex_table_name")
 
 
-def test_drop_outdated_partitions_no_found(mocker: MockerFixture, mock_table_partitioned: Table):
+def test_drop_outdated_partitions_no_found(
+    mocker: MockerFixture, mock_table_partitioned: Table
+):
     """
     Test to check if the function 'drop_outdated_partitions' correctly
     drops the partitions in the fact table that are outdated.
@@ -430,7 +432,7 @@ def test_drop_outdated_partitions_no_found(mocker: MockerFixture, mock_table_par
     cursor_mock = MagicMock()
     connection.cursor.return_value = cursor_mock
 
-    does_table_exists_mock = mocker.patch(
+    mocker.patch(
         "firebolt_ingest.table_service.does_table_exist", return_value=[True, True]
     )
 
@@ -442,5 +444,5 @@ def test_drop_outdated_partitions_no_found(mocker: MockerFixture, mock_table_par
 
     # Ensure no ALTER TABLE DROP PARTITION queries were called
     for call_args in cursor_mock.execute.call_args_list:
-        executed_query = call_args[1].get('query')
+        executed_query = call_args[1].get("query")
         assert not executed_query.startswith("ALTER TABLE table_name DROP PARTITION")


### PR DESCRIPTION
we have been using this functionality for last 2 years with pipelines where files with the same filenames can be unpredictably changed/updated by some external force (aws cost and usage report extract for example). 